### PR TITLE
Sharing output between chained scripts, output refactor and graceful error handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ https://github.com/user-attachments/assets/1e55e994-e2b2-4e4b-aed5-4e5f01ca0fd3
 Property **scripts** have only three reserved properties - path, requirement("pwsh" if required) and inputs(described below). Any other defined properties are passed to the powershell script as data (described in next section).
 
 ## Providing data to script
-Currently there are three ways of providing data to scripts:
+Currently there are four ways of providing data to scripts:
 - Static/predefined data
 - Dynamic input handling before the script runs
 - Dynamic input handling during script execution (Read-Host)

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ Currently there are three ways of providing data to scripts:
 - Static/predefined data
 - Dynamic input handling before the script runs
 - Dynamic input handling during script execution (Read-Host)
+- Output as an input for chained script
 
 ### Static/predefined data
 As mentioned earlier, these are the attributes from the json file defined for each script.
@@ -263,8 +264,9 @@ By prefixing the message with [INPUT], the Electron application can:
 
 This approach ensures seamless real-time interaction between the Electron application and PowerShell scripts, allowing dynamic input handling without causing scripts to hang.
 
-## Running multiple scripts
-If needed, multiple scripts can be defined within a single command.
+### Output as an input for chained script
+
+It is possible to chain multiple scripts within a single command, and it is also possible to use output from the script as an input for all subsequent chained scripts.
 ```json
 {
     "id":"restart-multiple-services",
@@ -287,6 +289,23 @@ If needed, multiple scripts can be defined within a single command.
         }
     ]
 }
+```
+
+To provide the output as an input, it is neccessary to output the data as JSON.
+```powershell
+# 1st chained script
+$object = @{"foo" = "bar"} | ConvertTo-Json
+Write-host $object
+```
+When this is done, we can access this data in all subsequent scripts from -jsondata parameter where it is stored in *chain* object.
+```powershell
+# 2nd chained script
+param (
+    [string]$jsondata
+)
+$data = $jsondata | ConvertFrom-Json
+
+$data.chain.foo #bar
 ```
 
 

--- a/src/commands.json
+++ b/src/commands.json
@@ -276,6 +276,33 @@
                     "test": "TWO"
                 }
             ]
+        },
+        {
+            "id":"chain-output",
+            "options":{
+                "name":"Chaining output",
+                "menu-id":"examples"
+            },
+            "scripts":[
+                {
+                    "path":"chainExample.ps1"
+                },
+                {
+                    "path":"chainExample.ps1"
+                },
+                {
+                    "path":"chainExample.ps1"
+                },
+                {
+                    "path":"chainExample.ps1"
+                },
+                {
+                    "path":"chainExample.ps1"
+                },
+                {
+                    "path":"chainExample.ps1"
+                }
+            ]
         }
     ]
 }

--- a/src/functions.js
+++ b/src/functions.js
@@ -129,45 +129,25 @@ async function spawnPowershell(script, mainWindow, commandName) {
     );
 
     powershell.stdout.on("data", (data) => {
-        let output = data.toString().trim();
-        output = output.replace(/\x1B\[[0-9;]*[mK]/g, ""); // PS7 ansi escape codes
-        if (output.startsWith("[ERROR]")) {
-            output = output.replace("[ERROR]", "").trim();
-            mainWindow.webContents.send("write-output", `<span class="error-output">${output}</span>`);
-            logYALV('warn', output);
-        } else if (output.startsWith("[XML]")) {
-            output = output.replace("[XML]", "").trim();
-            mainWindow.webContents.send("write-output", output, true);
-            logYALV(output);
-        } else if(output.startsWith("[INPUT]")) {
-            output = output.replace("[INPUT]", "").trim();
-            mainWindow.webContents.send("write-output", output);
-            mainWindow.webContents.send("request-read-host");
-        } else if(isJsonString(output)) {
-            const parsedOutput = JSON.parse(output);
-            Object.assign(chainData, parsedOutput);
-        } else {
-            mainWindow.webContents.send("write-output", output);
-        }       
+        handlePowershellOutput(data, mainWindow, false);      
     });
 
     ipcMain.on("submit-read-host", (event, message) => {
+        logYALV('Read-Host input provided: ' + message);
         powershell.stdin.write(message + "\r\n");
     });
 
     powershell.stderr.on("data", (data) => {
-        output = data.toString().trim();
-        output = output.replace(/\x1B\[[0-9;]*[mK]/g, ""); // PS7 ansi escape codes
-        mainWindow.webContents.send("write-output", 
-            `<span class="error-output">Error: ${output}</span>`);
-        logYALV("error", output);
+        handlePowershellOutput(data, mainWindow, true); 
     });
     await new Promise((resolve, reject) => {
         powershell.on("close", (code) => {
             if (code === 0) {
                 resolve();
             } else {
-                reject(new Error(`Script failed with exit code ${code}`));
+                mainWindow.webContents.send("write-output", `<span class="error-output">Script failed with exit code ${code}</span>`);
+                logYALV("error", `Script failed with exit code ${code}`);
+                resolve();
             }
         });
     });
@@ -263,11 +243,51 @@ async function getHashFromJson(script) {
     }
 }
 
-function isJsonString(str) {
-    try {
-        JSON.parse(str);
-        return true;
-    } catch (e) {
-        return false;
+function handlePowershellOutput(data, mainWindow, error) {
+    let output = data.toString().trim().replace(/\x1B\[[0-9;]*[mK]/g, "");
+    const prefix = {
+        error: "[ERROR]",
+        xml: "[XML]",
+        input: "[INPUT]",
+    };
+
+    if (error || output.startsWith(prefix.error)) {
+        if (output.startsWith(prefix.error)) {
+            output = output.slice(prefix.error.length).trim();
+            logYALV('warn', output);
+        } else {
+            logYALV("error", output);
+            output = `Error: ${output}`;
+        }
+        mainWindow.webContents.send("write-output", `<span class="error-output">${output}</span>`);
+        return;
+    }
+
+    const tryParseJson = (str) => {
+        try {
+            return { success: true, data: JSON.parse(str) };
+        } catch (e) {
+            return { success: false };
+        }
+    };
+
+    if (output.startsWith(prefix.xml)) {
+        output = output.slice(prefix.xml.length).trim();
+        mainWindow.webContents.send("write-output", output, true);
+        logYALV(output);
+        return;
+    } else if(output.startsWith(prefix.input)) {
+        output = output.slice(prefix.input.length).trim();
+        mainWindow.webContents.send("write-output", output);
+        mainWindow.webContents.send("request-read-host");
+        logYALV('Read-Host Input request received.');
+        return;
+    }
+
+    const parsedJson = tryParseJson(output);
+    if (parsedJson.success) {
+        Object.assign(chainData, parsedJson.data);
+    } else {
+        mainWindow.webContents.send("write-output", output);
     }
 }

--- a/src/scripts/chainExample.ps1
+++ b/src/scripts/chainExample.ps1
@@ -1,0 +1,20 @@
+param (
+    [string]$jsondata
+)
+$data = $jsondata | ConvertFrom-Json
+
+start-sleep -seconds 1
+
+if ($data.chain.increment) {
+    $newValue = $data.chain.increment + 1
+    $output = "Same script. Current value: " + $newValue
+    Write-Host $output
+
+    $object = @{"increment" = $newValue} | ConvertTo-Json
+    Write-host $object
+} else {
+    write-host "First script iteration. Start increment."
+    $object = @{"increment" = 1} | ConvertTo-Json
+    Write-host $object
+}
+


### PR DESCRIPTION
1. If the stdout output is valid JSON, it's stored in the chainData object. This object is then copied to the script object, which gets passed to all subsequent scripts via the -jsondata parameter.
This allows every script in the chain to access the data using $data.chain.XY.
Object chainData is cleared after all the chained scripts are executed.
```powershell
param (
    [string]$jsondata
)
$data = $jsondata | ConvertFrom-Json

if ($data.chain.foo) {
    Write-Host "Another run of the same script."
} else {
    Write-Host "First run of the script."
    $object = @{"foo" = "bar"} | ConvertTo-Json
    Write-host $object
}
```

2. Both stdout and stderr output was moved to own handlePowershellOutput function
3. PS error exit code is handled gracefully with error output and resolve